### PR TITLE
fix Unable to autoload constant ActiveStorage::Blob::Analyzable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Upyun service for activestorage.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'activestorage_upyun'
+gem 'activestorage_upyun', require: false
 ```
 
 Set up upyun storage service in config/storage.yml:
@@ -13,9 +13,9 @@ Set up upyun storage service in config/storage.yml:
 ```yml
 upyun:
   service: Upyun
-  bucket: <%= ENV['UPYUUN_BUCKET'] %>
-  operator: <%= ENV['UPYUUN_OPERATOR'] %>
-  password: <%= ENV['UPYUUN_PASSWORD'] %>
+  bucket: <%= ENV['UPYUN_BUCKET'] %>
+  operator: <%= ENV['UPYUN_OPERATOR'] %>
+  password: <%= ENV['UPYUN_PASSWORD'] %>
   host: <%= ENV['UPYUN_HOST'] %>
   folder: <%= ENV['UPYUN_FOLDER'] %>
 ```
@@ -43,9 +43,9 @@ thumb version use `!` as default identifier, if you want to use `_` as identifie
 ```yml
 upyun:
   service: Upyun
-  bucket: <%= ENV['UPYUUN_BUCKET'] %>
-  operator: <%= ENV['UPYUUN_OPERATOR'] %>
-  password: <%= ENV['UPYUUN_PASSWORD'] %>
+  bucket: <%= ENV['UPYUN_BUCKET'] %>
+  operator: <%= ENV['UPYUN_OPERATOR'] %>
+  password: <%= ENV['UPYUN_PASSWORD'] %>
   host: <%= ENV['UPYUN_HOST'] %>
   folder: <%= ENV['UPYUN_FOLDER'] %>
   identifier: _

--- a/lib/active_storage/service/upyun_service.rb
+++ b/lib/active_storage/service/upyun_service.rb
@@ -1,3 +1,5 @@
+require "upyun"
+
 module ActiveStorage
   # Wraps the upyun Storage Service as an Active Storage service.
   # See ActiveStorage::Service for the generic API documentation that applies to all services.
@@ -7,9 +9,9 @@ module ActiveStorage
   #
   #   upyun:
   #     service: Upyun
-  #     bucket: <%= ENV['UPYUUN_BUCKET'] %>
-  #     operator: <%= ENV['UPYUUN_OPERATOR'] %>
-  #     password: <%= ENV['UPYUUN_PASSWORD'] %>
+  #     bucket: <%= ENV['UPYUN_BUCKET'] %>
+  #     operator: <%= ENV['UPYUN_OPERATOR'] %>
+  #     password: <%= ENV['UPYUN_PASSWORD'] %>
   #     host: <%= ENV['UPYUN_HOST'] %>
   #     folder: <%= ENV['UPYUN_FOLDER'] %>
   #

--- a/lib/activestorage_upyun.rb
+++ b/lib/activestorage_upyun.rb
@@ -1,6 +1,4 @@
-require "upyun"
 require "activestorage_upyun/version"
 require 'active_storage/service/upyun_service'
 module ActivestorageUpyun
-  # Your code goes here...
 end


### PR DESCRIPTION
New rails 5.2.0 show Unable to autoload constant ActiveStorage::Blob::Analyzable for this gem, see here: 

https://stackoverflow.com/questions/50307502/blob-error-with-active-storage-rails-5-2

We need use `gem 'activestorage_upyun', require: false` instead of `gem 'activestorage_upyun'`.

So I make this PR for it.